### PR TITLE
sync_dir s3 url fix

### DIFF
--- a/ml_dronebase_data_utils/s3.py
+++ b/ml_dronebase_data_utils/s3.py
@@ -150,7 +150,7 @@ def sync_dir(s3_url: str, local_path: str) -> None:
     """
     bucket_name, prefix = _parse_url(s3_url)
     os.makedirs(local_path)
-    os.system(f"aws s3 sync s3://{bucket_name}/{prefix}/ {local_path}")
+    os.system(f"aws s3 sync s3://{bucket_name}/{prefix} {local_path}")
 
 
 def split_dataset(


### PR DESCRIPTION
When trying to use `sync_dir` recently, I noticed the `_parse_url` returns a s3 url prefix with a `/` at the end which conflicts with sync call: `os.system(f"aws s3 sync s3://{bucket_name}/{prefix}/ {local_path}")` which results in the sync failing because it's looking for a s3 path ending with `//`. This PR fixes this issue.