### PR TITLE
Added list_prefix function

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,12 +2,11 @@ name: Publish Python Package
 
 on:
   push:
-    branches:
-    - master
+    branches: [ main ]
 
 jobs:
   deploy:
-    
+
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +21,9 @@ jobs:
         pip install build
     - name: Build package
       run: python -m build
-    - name: Publish distribution to PyPI
+    - name: Publish distribution to DroneBase-ML Private PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        user: ${{ secrets.PRIVATE_PYPI_USER }}
+        password: ${{ secrets.PRIVATE_PYPI_PSWD }}
+        repository_url: ${{ secrets.PRIVATE_PYPI_REPO }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish Python Package
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Dronebase Machine Learning Data Utils
 
-## PUBLIC FACING
-
 This package contains commonly used data functions for ML Engineers
 
 ```python

--- a/ml_dronebase_data_utils/__init__.py
+++ b/ml_dronebase_data_utils/__init__.py
@@ -1,4 +1,4 @@
 from . import pascal_voc, s3  # noqa: F401
 
 __author__ = "Conor Wallace"
-__version__ = ""
+__version__ = "0.0.1"

--- a/ml_dronebase_data_utils/s3.py
+++ b/ml_dronebase_data_utils/s3.py
@@ -28,6 +28,38 @@ def is_json(myjson: str) -> bool:
     return True
 
 
+def list_prefix(
+    s3_url: str,
+    filter_files: Optional[bool] = False,
+    filter_prefixes: Optional[bool] = False,
+) -> List[str]:
+    """List all files and prefixes within the path of the given url.
+
+    Args:
+        s3_url (str): The s3 url to list from.
+        filter_files (Optional[bool]): If true, output will only contain the files within the given url.
+        Defaults to False.
+        filter_prefixes (Optional[bool]): If true, output will only contain the prefixes within the given url.
+        Defaults to False.
+
+    Returns:
+        List[str]: The files and/or prefixes within the given url.
+    """
+    s3 = boto3.resource("s3")
+    bucket_name, prefix = _parse_url(s3_url)
+    bucket = s3.Bucket(bucket_name)
+    objects = bucket.objects.filter(Prefix=prefix)
+    files = [obj.key for obj in objects if obj.key != prefix]
+
+    assert not filter_files and filter_prefixes, "Can't filter files and prefixes"
+
+    if filter_files:
+        files = [file for file in files if file[-1] != "/"]
+    elif filter_prefixes:
+        files = [file for file in files if file[-1] == "/"]
+    return files
+
+
 def upload_file(local_path: str, s3_url: str, exist_ok: bool = True):
     """Upload file to s3 bucket.
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 if __name__ == "__main__":
     setup(
         name="ml-dronebase-data-utils",
-        version="0.0.5",
+        version="0.0.1",
         description="A collection of commonly functions used by DroneBase ML Engineers",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
Added a ```list_prefix``` function that takes in an s3 url which mimics ```os.listdir()``` which returns a list of objects within the given url. Two optional args ```filter_files``` and ```filter_prefixes``` allows the user to specify to return only the files or prefixes within the given url.

Additionally, this package has been converted to publish to the DroneBase-ML private PyPi repo.