### PR TITLE
Adding options to specify class mappings

### DIFF
--- a/ml_dronebase_data_utils/convert_geojson.py
+++ b/ml_dronebase_data_utils/convert_geojson.py
@@ -60,8 +60,8 @@ def get_pixel_vertices(ortho: DatasetReader, gdf: GeoDataFrame) -> np.ndarray:
     geo_vertices = [p.exterior.coords for p in polys]
 
     pxl_vertices = []
-    for i, geo_v in enumerate(tqdm(geo_vertices, total=len(geo_vertices))):
-        pxl_v = [ortho.index(x, y) for x, y in geo_v]
+    for _, geo_v in enumerate(tqdm(geo_vertices, total=len(geo_vertices))):
+        pxl_v = [ortho.index(c[0], c[1]) for c in geo_v[:2]]
         pxl_v = np.asarray(pxl_v)
         # swap axes (y, x) -> (x, y)
         pxl_v[:, [1, 0]] = pxl_v[:, [0, 1]]

--- a/ml_dronebase_data_utils/convert_geojson.py
+++ b/ml_dronebase_data_utils/convert_geojson.py
@@ -61,7 +61,7 @@ def get_pixel_vertices(ortho: DatasetReader, gdf: GeoDataFrame) -> np.ndarray:
 
     pxl_vertices = []
     for _, geo_v in enumerate(tqdm(geo_vertices, total=len(geo_vertices))):
-        pxl_v = [ortho.index(c[0], c[1]) for c in geo_v[:2]]
+        pxl_v = [ortho.index(c[0], c[1]) for c in geo_v]
         pxl_v = np.asarray(pxl_v)
         # swap axes (y, x) -> (x, y)
         pxl_v[:, [1, 0]] = pxl_v[:, [0, 1]]

--- a/test_conversion.py
+++ b/test_conversion.py
@@ -1,0 +1,8 @@
+from ml_dronebase_data_utils.convert_geojson import geo_to_voc
+
+if __name__ == "__main__":
+    ortho_path = "s3://ml-solar-ortho-fault-detection/orthos/tiff/PA140004_Thermal.tif"
+    geojson_path = "s3://ml-solar-ortho-fault-detection/orthos/geojson/PA140004_Thermal.geojson"
+    save_path = "s3://ml-solar-ortho-fault-detection/orthos/annotations/PA140004_Thermal.xml"
+
+    geo_to_voc(ortho_path,geojson_path,save_path)

--- a/test_conversion.py
+++ b/test_conversion.py
@@ -4,5 +4,23 @@ if __name__ == "__main__":
     ortho_path = "s3://ml-solar-ortho-fault-detection/orthos/tiff/PA140004_Thermal.tif"
     geojson_path = "s3://ml-solar-ortho-fault-detection/orthos/geojson/PA140004_Thermal.geojson"
     save_path = "s3://ml-solar-ortho-fault-detection/orthos/annotations/PA140004_Thermal.xml"
-
-    geo_to_voc(ortho_path,geojson_path,save_path)
+    class_attribute = "id"
+    class_mapping = {
+        0: 'Normal',
+        1: 'Diode',
+        2: 'Panel Offline',
+        3: 'String Offline',
+        4: 'Panel Off-Tilt',
+        5: 'PID',
+        6: 'Soiling',
+        7: 'Shading',
+        8: 'Reverse Polarity',
+        9: 'Glass Broken',
+        10: 'No Panel Data',
+        11: 'Hot Cell',
+        12: 'Hot Cell',
+        13: 'Hot Cell',
+        14: 'Multiple Hot Cells'
+    }
+    skip_classes = [0,1,2,4,5,6,7,8,9,10,14]
+    geo_to_voc(ortho_path,geojson_path,save_path,class_attribute,class_mapping,skip_classes=skip_classes)


### PR DESCRIPTION
Modified `convert_geojson.py` to take in class based on an attribute specified in the geojson without breaking backward compatibility.
The new features include:
1. Specify an attribute to be used as the class
2. Use default_class for single class conversions
3. Specify a mapping for the values, e.g. attribute has a value 1 which represents Apple class.
4. Specify a list of classes to be skipped
